### PR TITLE
Prevent use buildPipeForClass instead of forClass

### DIFF
--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/impl/pipeline/RestfulPipeConfiguration.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/impl/pipeline/RestfulPipeConfiguration.java
@@ -57,7 +57,7 @@ public class RestfulPipeConfiguration extends PipeConfiguration<RestfulPipeConfi
 
     @Override
     protected <DATA> Pipe<DATA> buildPipeForClass(Class<DATA> aClass) {
-        if (url == null) {
+        if (this.url == null) {
             throw new IllegalStateException("url may not be null");
         }
         


### PR DESCRIPTION
This PR prevent developer call buildPipeForClass instead of forClass to create a Pipe instance
