### PR TITLE
Giving testReadFilter a travis appropriate timeout

### DIFF
--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/impl/pipeline/LoaderAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/impl/pipeline/LoaderAdapterTest.java
@@ -632,7 +632,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                         TAG, e);
             }
         });
-        latch.await(500, TimeUnit.MILLISECONDS);
+        latch.await(60, TimeUnit.SECONDS);
 
         verify(factory).get(Mockito.argThat(new ObjectVarArgsMatcher(new URL("http://server.com/context?limit=10&model=BMW"), 60000)));
 


### PR DESCRIPTION
@qmx @danielpassos :eyes: ?

Very very small change
