### PR TITLE
Rename loader get method to the same method name of pipe

### DIFF
--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/LoaderAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/LoaderAdapterTest.java
@@ -129,7 +129,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         List<LoaderAdapterTest.ListClassId> result = runRead(adapter);
 
@@ -162,7 +162,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         try {
             adapter.read(new AbstractFragmentCallback<List<LoaderAdapterTest.ListClassId>>() {
@@ -205,7 +205,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         try {
 
@@ -252,7 +252,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         try {
             adapter.remove("1", new AbstractFragmentCallback<Void>() {
@@ -309,7 +309,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         runSave(adapter);
 
@@ -350,7 +350,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<MultiPartData> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<MultiPartData> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean hasException = new AtomicBoolean(false);
@@ -404,7 +404,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     }
                 });
 
-        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.get(config.getName(), getActivity());
+        LoaderPipe<LoaderAdapterTest.ListClassId> adapter = PipeManager.getPipe(config.getName(), getActivity());
 
         runRemove(adapter, "1");
 
@@ -622,7 +622,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
         filter.setLimit(10);
         filter.setWhere(new JSONObject("{\"model\":\"BMW\"}"));
 
-        LoaderAdapter<Data> adapter = (LoaderAdapter<Data>) PipeManager.get("data", getActivity());
+        LoaderAdapter<Data> adapter = (LoaderAdapter<Data>) PipeManager.getPipe("data", getActivity());
 
         adapter.read(filter, new Callback<List<Data>>() {
             private static final long serialVersionUID = 1L;

--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/PipeManager.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/PipeManager.java
@@ -115,7 +115,7 @@ public class PipeManager {
      * @return the new created Pipe object
      * 
      */
-    public static LoaderPipe get(String name, Activity activity) {
+    public static LoaderPipe getPipe(String name, Activity activity) {
         Pipe pipe = pipes.get(name);
         LoaderAdapter adapter = new LoaderAdapter(activity, pipe, name);
         adapter.setLoaderIds(loaderIdsForNamed);
@@ -132,7 +132,7 @@ public class PipeManager {
      * @return the new created Pipe object
      * 
      */
-    public static LoaderPipe get(String name, Fragment fragment, Context applicationContext) {
+    public static LoaderPipe getPipe(String name, Fragment fragment, Context applicationContext) {
         Pipe pipe = pipes.get(name);
         LoaderAdapter adapter = new LoaderAdapter(fragment, applicationContext, pipe, name);
         adapter.setLoaderIds(loaderIdsForNamed);


### PR DESCRIPTION
As we decided in https://github.com/aerogear/aerogear-android-pipe/pull/25, the correct is rename the Loader get method to the same of the pipe get method as all of the other managers, following the getXXX pattern