### PR TITLE
Junit4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ android:
     - build-tools-21.1.1
     - android-21
     - android-19
+    - extra-android-support
+    - extra-google-m2repository
+    - extra-android-m2repository
     - sys-img-armeabi-v7a-android-19
 
 env:
@@ -38,6 +41,10 @@ before_install:
   # Install android maven repository
   - cd $PWD/maven-android-sdk-deployer/platforms/$ANDROID_SDK
   - mvn  install -N --quiet
+  - cd -
+
+  - cd $PWD/maven-android-sdk-deployer/repositories
+  - mvn  install 
   - cd -
 
   #################################################

--- a/aerogear-android-pipe-test/pom.xml
+++ b/aerogear-android-pipe-test/pom.xml
@@ -31,8 +31,8 @@
     
     <properties>
         <mockito.version>1.9.5</mockito.version>
-        <dexmaker.version>1.0</dexmaker.version>
-        <dexmaker.mockito.version>1.0</dexmaker.mockito.version>
+        <dexmaker.version>1.2</dexmaker.version>
+        <dexmaker.mockito.version>1.2</dexmaker.mockito.version>
     </properties>
     
     <dependencies>
@@ -41,6 +41,51 @@
             <groupId>org.jboss.aerogear</groupId>
             <artifactId>aerogear-android-pipe</artifactId>
             <version>${project.version}</version>
+            <type>aar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-pipe</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>runner</artifactId>
+            <version>0.2</version>
+            <type>aar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+            <version>4.10</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hamcrest-core</artifactId>
+                    <groupId>org.hamcrest</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>rules</artifactId>
+            <version>0.2</version>
             <type>aar</type>
         </dependency>
         <dependency>
@@ -58,6 +103,7 @@
             <groupId>com.google.dexmaker</groupId>
             <artifactId>dexmaker</artifactId>
             <version>${dexmaker.version}</version>
+            
             <exclusions>
                 <exclusion>
                     <artifactId>hamcrest-core</artifactId>

--- a/aerogear-android-pipe-test/src/main/AndroidManifest.xml
+++ b/aerogear-android-pipe-test/src/main/AndroidManifest.xml
@@ -2,14 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.jboss.aerogear.android.pipe.test">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
     <instrumentation
-        android:name="android.test.InstrumentationTestRunner"
+        android:name="android.support.test.runner.AndroidJUnitRunner"
         android:targetPackage="org.jboss.aerogear.android.pipe.test" />
 
     <application

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/http/HttpHelperTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/http/HttpHelperTest.java
@@ -16,20 +16,26 @@
  */
 package org.jboss.aerogear.android.pipe.test.http;
 
+import android.support.test.runner.AndroidJUnit4;
 import java.util.HashMap;
 
-import android.test.AndroidTestCase;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotSame;
 import org.jboss.aerogear.android.pipe.http.HeaderAndBody;
 import org.jboss.aerogear.android.pipe.http.HttpException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class HttpHelperTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class HttpHelperTest {
     private static final byte[] SIMPLE_DATA = { 8, 6, 7, 5, 3, 0, 9 };
     private static final String SAMPLE_MESSAGE = "SAMPLE_MESSAGE";
     private static final String SAMPLE_HEADER = "SAMPLE_HEADER";
     private static final String DEFAULT_MESSAGE = "The server returned the error code 404.";
     private static final int NOT_FOUND = 404;
 
-    public void testHttpExceptionConstructor() {
+    @Test
+    public void constructsHttpException() {
         HttpException exception = new HttpException(SIMPLE_DATA, NOT_FOUND);
         HttpException exceptionWithMessage = new HttpException(SIMPLE_DATA,
                 NOT_FOUND, SAMPLE_MESSAGE);
@@ -44,7 +50,8 @@ public class HttpHelperTest extends AndroidTestCase {
 
     }
 
-    public void testHeaderAndBody() {
+    @Test
+    public void constructHeaderAndBody() {
         HeaderAndBody headerAndBody = new HeaderAndBody(SIMPLE_DATA,
                 new HashMap<String, Object>());
         headerAndBody.setHeader(SAMPLE_HEADER, SAMPLE_MESSAGE);

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/http/HttpRestProviderTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/http/HttpRestProviderTest.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.android.pipe.test.http;
 
+import android.support.test.runner.AndroidJUnit4;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -36,6 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.fail;
 import org.jboss.aerogear.android.core.Provider;
 import org.jboss.aerogear.android.pipe.http.HeaderAndBody;
 import org.jboss.aerogear.android.pipe.http.HttpException;
@@ -45,8 +49,11 @@ import org.mockito.stubbing.Answer;
 
 import org.jboss.aerogear.android.pipe.test.util.PatchedActivityInstrumentationTestCase;
 import org.jboss.aerogear.android.pipe.test.MainActivity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase<MainActivity> {
+@RunWith(AndroidJUnit4.class)
+public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase {
 
     private static final URL SIMPLE_URL;
     private static final String HEADER_KEY1_NAME = "KEY1";
@@ -79,6 +86,7 @@ public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase
         super(MainActivity.class);
     }
 
+    @Test
     public void testGetFailsWith404() throws Exception {
         try {
             HttpURLConnection connection404 = mock(HttpURLConnection.class);
@@ -107,6 +115,7 @@ public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase
         fail("Expected HttpException exception");
     }
 
+    @Test
     public void testGet() throws Exception {
         HttpURLConnection connection = mock(HttpURLConnection.class);
         HttpRestProvider provider = new HttpRestProvider(SIMPLE_URL);
@@ -128,6 +137,7 @@ public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase
 
     }
 
+    @Test
     public void testPost() throws Exception {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(
@@ -159,6 +169,7 @@ public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase
 
     }
 
+    @Test
     public void testPut() throws Exception {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(
                 RESPONSE_DATA.length);
@@ -193,6 +204,7 @@ public class HttpRestProviderTest extends PatchedActivityInstrumentationTestCase
         assertEquals(id, providerProvider.id);
     }
 
+    @Test
     public void testDelete() throws Exception {
         HttpURLConnection connection = mock(HttpURLConnection.class);
         HttpUrlConnectionProvider providerProvider = new HttpUrlConnectionProvider(

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/CallbackTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/CallbackTest.java
@@ -18,6 +18,10 @@ package org.jboss.aerogear.android.pipe.test.loader;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.support.test.runner.AndroidJUnit4;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 import org.jboss.aerogear.android.pipe.callback.AbstractActivityCallback;
 import org.jboss.aerogear.android.pipe.callback.AbstractFragmentCallback;
 import org.jboss.aerogear.android.pipe.loader.LoaderAdapter;
@@ -27,16 +31,20 @@ import org.jboss.aerogear.android.pipe.loader.LoaderAdapter.CallbackHandler;
 import org.jboss.aerogear.android.pipe.test.util.PatchedActivityInstrumentationTestCase;
 import org.jboss.aerogear.android.pipe.test.MainActivity;
 import org.jboss.aerogear.android.pipe.Pipe;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 
+@RunWith(AndroidJUnit4.class)
 @SuppressWarnings({ "unchecked", "rawtypes" })
-public class CallbackTest extends PatchedActivityInstrumentationTestCase<MainActivity> {
+public class CallbackTest extends PatchedActivityInstrumentationTestCase {
 
     public CallbackTest() {
         super(MainActivity.class);
     }
 
+    @Test
     public void testPassModernFragmentCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
         Fragment fragment = Mockito.mock(Fragment.class);
 
@@ -53,6 +61,7 @@ public class CallbackTest extends PatchedActivityInstrumentationTestCase<MainAct
 
     }
 
+    @Test
     public void testFailModernFragmentCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
         Fragment fragment = Mockito.mock(Fragment.class);
 
@@ -71,6 +80,7 @@ public class CallbackTest extends PatchedActivityInstrumentationTestCase<MainAct
 
     }
 
+    @Test
     public void testPassModernActivityCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
         Activity activity = Mockito.mock(Activity.class);
 
@@ -87,6 +97,7 @@ public class CallbackTest extends PatchedActivityInstrumentationTestCase<MainAct
 
     }
 
+    @Test
     public void testFailModernActivityCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
         Activity activity = Mockito.mock(Activity.class);
 

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/LoaderAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/LoaderAdapterTest.java
@@ -39,8 +39,6 @@ import java.util.logging.Logger;
 
 import junit.framework.Assert;
 
-import org.jboss.aerogear.android.pipe.PipeManager;
-import org.jboss.aerogear.android.pipe.callback.AbstractFragmentCallback;
 import org.jboss.aerogear.android.pipe.loader.LoaderAdapter;
 import org.jboss.aerogear.android.pipe.loader.ReadLoader;
 import org.jboss.aerogear.android.pipe.loader.RemoveLoader;
@@ -69,6 +67,7 @@ import org.mockito.Mockito;
 import android.annotation.TargetApi;
 import android.graphics.Point;
 import android.os.Build;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.InstanceCreator;
@@ -81,14 +80,20 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
 import org.jboss.aerogear.android.pipe.test.util.PatchedActivityInstrumentationTestCase;
 import org.jboss.aerogear.android.pipe.callback.AbstractFragmentCallback;
 import org.jboss.aerogear.android.pipe.PipeManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-@SuppressWarnings({ "unchecked", "rawtypes" })
-public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<MainActivity> {
+@SuppressWarnings({"unchecked", "rawtypes"})
+@RunWith(AndroidJUnit4.class)
+public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase {
 
     public LoaderAdapterTest() {
         super(MainActivity.class);
@@ -100,12 +105,13 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
     private URL url;
     private URL listUrl;
 
+    @Before
     public void setUp() throws MalformedURLException, Exception {
-        super.setUp();
         url = new URL("http://server.com/context/");
         listUrl = new URL("http://server.com/context/ListClassId");
     }
 
+    @Test
     public void testSingleObjectRead() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -138,6 +144,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testReadCallbackFailsWithIncompatibleType() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -182,6 +189,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
         fail("Incorrect callback should throw exception.");
     }
 
+    @Test
     public void testSaveCallbackFailsWithIncompatibleType() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -228,6 +236,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testDeleteCallbackFailsWithIncompatibleType() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -273,6 +282,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testSingleObjectSave() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -283,14 +293,14 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
         when(provider.post((byte[]) anyObject()))
                 .thenReturn(new HeaderAndBody(
-                        SERIALIZED_POINTS.getBytes(),
-                        new HashMap<String, Object>())
+                                SERIALIZED_POINTS.getBytes(),
+                                new HashMap<String, Object>())
                 );
 
         when(provider.put(any(String.class), (byte[]) anyObject()))
                 .thenReturn(new HeaderAndBody(
-                        SERIALIZED_POINTS.getBytes(),
-                        new HashMap<String, Object>())
+                                SERIALIZED_POINTS.getBytes(),
+                                new HashMap<String, Object>())
                 );
 
         RestfulPipeConfiguration config = PipeManager.config("ListClassId", RestfulPipeConfiguration.class);
@@ -317,6 +327,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testSingleObjectMultipartSave() throws Exception {
 
         final HttpStubProvider provider = mock(HttpStubProvider.class);
@@ -324,14 +335,14 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
         when(provider.post((byte[]) anyObject()))
                 .thenReturn(new HeaderAndBody(
-                        SERIALIZED_POINTS.getBytes(),
-                        new HashMap<String, Object>())
+                                SERIALIZED_POINTS.getBytes(),
+                                new HashMap<String, Object>())
                 );
 
         when(provider.put(any(String.class), (byte[]) anyObject()))
                 .thenReturn(new HeaderAndBody(
-                        SERIALIZED_POINTS.getBytes(),
-                        new HashMap<String, Object>())
+                                SERIALIZED_POINTS.getBytes(),
+                                new HashMap<String, Object>())
                 );
 
         RestfulPipeConfiguration config = PipeManager.config("MultiPartData", RestfulPipeConfiguration.class);
@@ -368,7 +379,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     public void onFailure(Exception e) {
                         hasException.set(true);
                         Logger.getLogger(LoaderAdapterTest.class.getSimpleName())
-                                .log(Level.SEVERE, e.getMessage(), e);
+                        .log(Level.SEVERE, e.getMessage(), e);
                         latch.countDown();
                     }
                 });
@@ -380,6 +391,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testSingleObjectDelete() throws Exception {
 
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
@@ -412,10 +424,11 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testMultipleCallsToLoadCallDeliver() {
         PipeHandler handler = mock(PipeHandler.class);
         final AtomicBoolean called = new AtomicBoolean(false);
-        when(handler.onRawReadWithFilter((ReadFilter) any(), (Pipe) any())).thenReturn(new HeaderAndBody(new byte[] {}, new HashMap<String, Object>()));
+        when(handler.onRawReadWithFilter((ReadFilter) any(), (Pipe) any())).thenReturn(new HeaderAndBody(new byte[]{}, new HashMap<String, Object>()));
         ReadLoader loader = new ReadLoader(getActivity(), null, handler, null, null) {
 
             @Override
@@ -442,10 +455,11 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testMultipleCallsToSaveCallDeliver() {
         PipeHandler handler = mock(PipeHandler.class);
         final AtomicBoolean called = new AtomicBoolean(false);
-        when(handler.onRawSave(Matchers.anyString(), (byte[]) anyObject())).thenReturn(new HeaderAndBody(new byte[] {}, new HashMap<String, Object>()));
+        when(handler.onRawSave(Matchers.anyString(), (byte[]) anyObject())).thenReturn(new HeaderAndBody(new byte[]{}, new HashMap<String, Object>()));
         SaveLoader loader = new SaveLoader(getActivity(), null, handler, null, null) {
 
             @Override
@@ -472,10 +486,11 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testMultipleCallsToRemoveCallDeliver() {
         PipeHandler handler = mock(PipeHandler.class);
         final AtomicBoolean called = new AtomicBoolean(false);
-        when(handler.onRawReadWithFilter((ReadFilter) any(), (Pipe) any())).thenReturn(new HeaderAndBody(new byte[] {}, new HashMap<String, Object>()));
+        when(handler.onRawReadWithFilter((ReadFilter) any(), (Pipe) any())).thenReturn(new HeaderAndBody(new byte[]{}, new HashMap<String, Object>()));
 
         RemoveLoader loader = new RemoveLoader(getActivity(), null, handler, null) {
 
@@ -510,7 +525,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
     /**
      * Runs a read method, returns the result of the call back and makes sure no
      * exceptions are thrown
-     * 
+     *
      * @param restPipe
      */
     private <T> List<T> runRead(Pipe<T> restPipe, ReadFilter readFilter)
@@ -546,7 +561,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
     /**
      * Runs a remove method, returns the result of the call back and makes sure
      * no exceptions are thrown
-     * 
+     *
      */
     private <T> void runRemove(Pipe<T> restPipe, String id)
             throws InterruptedException {
@@ -592,7 +607,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
                     public void onFailure(Exception e) {
                         hasException.set(true);
                         Logger.getLogger(LoaderAdapterTest.class.getSimpleName())
-                                .log(Level.SEVERE, e.getMessage(), e);
+                        .log(Level.SEVERE, e.getMessage(), e);
                         latch.countDown();
                     }
                 });
@@ -601,6 +616,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
         Assert.assertFalse(hasException.get());
     }
 
+    @Test
     public void testRunReadWithFilter() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -645,6 +661,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     }
 
+    @Test
     public void testResetWithoutPipeIds() throws NoSuchFieldException, IllegalAccessException {
         RestfulPipeConfiguration config = PipeManager.config("data", RestfulPipeConfiguration.class);
         Pipe<Data> pipe = config.withUrl(url).forClass(Data.class);
@@ -652,8 +669,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
         LoaderAdapter<Data> loaderPipe = new LoaderAdapter<Data>(getActivity(), pipe, "loaderPipeForTest");
         loaderPipe.reset();
 
-        Map<String, List<Integer>> idsForNamedPipes = (Map<String, List<Integer>>)
-                UnitTestUtils.getPrivateField(loaderPipe, "idsForNamedPipes");
+        Map<String, List<Integer>> idsForNamedPipes = (Map<String, List<Integer>>) UnitTestUtils.getPrivateField(loaderPipe, "idsForNamedPipes");
 
         Assert.assertEquals("Should be 1", 1, idsForNamedPipes.size());
         Assert.assertNotNull("Should not null", idsForNamedPipes.get("loaderPipeForTest"));
@@ -723,7 +739,7 @@ public class LoaderAdapterTest extends PatchedActivityInstrumentationTestCase<Ma
 
     public static class MultiPartData {
 
-        private byte[] byteArray = { 'a', 'b', 'c', 'd', 'e', 'f' };
+        private byte[] byteArray = {'a', 'b', 'c', 'd', 'e', 'f'};
         private InputStream inputStream = new ByteArrayInputStream(byteArray);
 
         @RecordId

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/paging/PagedListTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/paging/PagedListTest.java
@@ -1,21 +1,22 @@
 /**
- * JBoss, Home of Professional Open Source
- * Copyright Red Hat, Inc., and individual contributors.
+ * JBoss, Home of Professional Open Source Copyright Red Hat, Inc., and
+ * individual contributors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.jboss.aerogear.android.pipe.test.paging;
 
+import android.support.test.runner.AndroidJUnit4;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -29,12 +30,15 @@ import org.jboss.aerogear.android.core.Callback;
 import org.jboss.aerogear.android.core.ReadFilter;
 import org.jboss.aerogear.android.pipe.Pipe;
 
-import android.test.AndroidTestCase;
 import org.jboss.aerogear.android.pipe.paging.WrappingPagedList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class PagedListTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class PagedListTest {
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
     public void testNext() {
         Pipe pipe = mock(Pipe.class);
         ReadFilter next = new ReadFilter();

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
@@ -1,23 +1,23 @@
 /**
- * JBoss, Home of Professional Open Source
- * Copyright Red Hat, Inc., and individual contributors.
+ * JBoss, Home of Professional Open Source Copyright Red Hat, Inc., and
+ * individual contributors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.jboss.aerogear.android.pipe.test.rest;
 
 import android.graphics.Point;
-import android.test.AndroidTestCase;
+import android.support.test.runner.AndroidJUnit4;
 import com.google.gson.*;
 import junit.framework.Assert;
 import org.jboss.aerogear.android.core.Callback;
@@ -64,12 +64,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-public class RestAdapterTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class RestAdapterTest {
 
     private static final String TAG = RestAdapterTest.class.getSimpleName();
     private static final String SERIALIZED_POINTS = "{\"points\":[{\"x\":0,\"y\":0},{\"x\":1,\"y\":2},{\"x\":2,\"y\":4},{\"x\":3,\"y\":6},{\"x\":4,\"y\":8},{\"x\":5,\"y\":10},{\"x\":6,\"y\":12},{\"x\":7,\"y\":14},{\"x\":8,\"y\":16},{\"x\":9,\"y\":18}],\"id\":\"1\"}";
@@ -82,12 +89,12 @@ public class RestAdapterTest extends AndroidTestCase {
         }
     };
 
-    @Override
+    @Before
     public void setUp() throws MalformedURLException, Exception {
-        super.setUp();
         url = new URL("http://server.com/context/");
     }
 
+    @Test
     public void testPipeURLProperty() throws Exception {
         Pipe<Data> restPipe = new RestAdapter<Data>(Data.class, url);
         Object restRunner = UnitTestUtils.getPrivateField(restPipe, "restRunner");
@@ -95,6 +102,7 @@ public class RestAdapterTest extends AndroidTestCase {
         assertEquals("verifying the given URL", "http://server.com/context/", restPipe.getUrl().toString());
     }
 
+    @Test
     public void testPipeFactoryPipeConfigEncoding() {
         try {
             RestfulPipeConfiguration config = PipeManager.config("data", RestfulPipeConfiguration.class).withUrl(url);
@@ -107,6 +115,7 @@ public class RestAdapterTest extends AndroidTestCase {
         fail("Expected IllegalArgumentException");
     }
 
+    @Test
     public void testPipeFactoryPipeConfigGson() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
         GsonResponseParser<ListClassId> responseParser = new GsonResponseParser<ListClassId>(builder.create());
@@ -125,6 +134,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testEncoding() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
         final Charset utf_16 = Charset.forName("UTF-16");
@@ -153,6 +163,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testConfigSetEncoding() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(
                 Point.class, new RestAdapterTest.PointTypeAdapter());
@@ -168,6 +179,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testSingleObjectRead() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
         HeaderAndBody response = new HeaderAndBody(SERIALIZED_POINTS.getBytes(), new HashMap<String, Object>());
@@ -191,6 +203,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testSingleObjectReadWithNestedResult() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
         HeaderAndBody response = new HeaderAndBody(("{\"result\":{\"points\":" + SERIALIZED_POINTS + "}}").getBytes(), new HashMap<String, Object>());
@@ -216,6 +229,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testReadArray() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
         HeaderAndBody response = new HeaderAndBody((POINTS_ARRAY).getBytes(), new HashMap<String, Object>());
@@ -240,6 +254,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testGsonBuilderProperty() throws Exception {
         GsonBuilder builder = new GsonBuilder().registerTypeAdapter(Point.class, new RestAdapterTest.PointTypeAdapter());
 
@@ -382,11 +397,15 @@ public class RestAdapterTest extends AndroidTestCase {
 
     /**
      * This test tests the default paging configuration.
-     * 
-     * @throws java.lang.NoSuchFieldException If this is thrown then the test is broken.
-     * @throws java.lang.IllegalAccessException If this is thrown then the test is broken.
-     * @throws java.lang.InterruptedException If this is thrown then the test is broken.
+     *
+     * @throws java.lang.NoSuchFieldException If this is thrown then the test is
+     * broken.
+     * @throws java.lang.IllegalAccessException If this is thrown then the test
+     * is broken.
+     * @throws java.lang.InterruptedException If this is thrown then the test is
+     * broken.
      */
+    @Test
     public void testLinkPagingReturnsData() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException, InterruptedException {
 
         final HttpStubProvider provider = new HttpStubProvider(url, new HeaderAndBody(SERIALIZED_POINTS.getBytes(), new HashMap<String, Object>()));
@@ -421,13 +440,14 @@ public class RestAdapterTest extends AndroidTestCase {
 
     /**
      * This test tests the default paging configuration.
-     * 
-     * 
+     *
+     *
      * @throws java.lang.InterruptedException this should not be thrown
      * @throws java.net.URISyntaxException this should not be thrown
      * @throws java.lang.NoSuchFieldException this should not be thrown
      * @throws java.lang.IllegalAccessException this should not be thrown
      */
+    @Test
     public void testDefaultPaging() throws InterruptedException, NoSuchFieldException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException,
             URISyntaxException {
 
@@ -465,6 +485,7 @@ public class RestAdapterTest extends AndroidTestCase {
         assertEquals(new URI("http://example.com/TheBook/chapter2"), pagedList.getPreviousFilter().getLinkUri());
     }
 
+    @Test
     public void testBuildPagedResultsFromHeaders() throws Exception {
         PageConfig pageConfig = new PageConfig();
         pageConfig.setMetadataLocation(PageConfig.MetadataLocations.HEADERS);
@@ -474,7 +495,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
         RestAdapter adapter = new RestAdapter(Data.class, url, config);
         List<Data> list = new ArrayList<Data>();
-        HeaderAndBody response = new HeaderAndBody(new byte[] {}, new HashMap<String, Object>() {
+        HeaderAndBody response = new HeaderAndBody(new byte[]{}, new HashMap<String, Object>() {
             {
                 put("next", "chapter3");
                 put("previous", "chapter2");
@@ -491,6 +512,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testBuildPagedResultsFromBody() throws Exception {
         PageConfig pageConfig = new PageConfig();
         pageConfig.setMetadataLocation(PageConfig.MetadataLocations.BODY);
@@ -514,6 +536,7 @@ public class RestAdapterTest extends AndroidTestCase {
 
     }
 
+    @Test
     public void testRunTimeout() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -541,6 +564,7 @@ public class RestAdapterTest extends AndroidTestCase {
         assertEquals(SocketTimeoutException.class, exceptionReference.get().getCause().getClass());
     }
 
+    @Test
     public void testReadByIdURL() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -579,7 +603,7 @@ public class RestAdapterTest extends AndroidTestCase {
     /**
      * Runs a read method, returns the result of the call back and makes sure no
      * exceptions are thrown
-     * 
+     *
      * @param restPipe
      */
     private <T> List<T> runRead(Pipe<T> restPipe, ReadFilter readFilter) throws InterruptedException {
@@ -611,7 +635,7 @@ public class RestAdapterTest extends AndroidTestCase {
     /**
      * Runs a read method, returns the result of the call back and rethrows the
      * underlying exception
-     * 
+     *
      * @param restPipe
      */
     private <T> List<T> runReadForException(Pipe<T> restPipe, ReadFilter readFilter) throws InterruptedException, Exception {

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/gson/GsonResponseParserTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/gson/GsonResponseParserTest.java
@@ -16,7 +16,8 @@
  */
 package org.jboss.aerogear.android.pipe.test.rest.gson;
 
-import android.test.AndroidTestCase;
+
+import android.support.test.runner.AndroidJUnit4;
 import junit.framework.Assert;
 import org.jboss.aerogear.android.pipe.http.HeaderAndBody;
 import org.jboss.aerogear.android.pipe.rest.gson.GsonResponseParser;
@@ -24,9 +25,13 @@ import org.jboss.aerogear.android.pipe.test.helper.Data;
 
 import java.util.HashMap;
 import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class GsonResponseParserTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class GsonResponseParserTest {
 
+    @Test
     public void testHandleResponseWithEmptyResponse() {
         String jsonResponse = "";
         HeaderAndBody httpResponse = new HeaderAndBody(jsonResponse.getBytes(), new HashMap<String, Object>());

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/PatchedActivityInstrumentationTestCase.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/PatchedActivityInstrumentationTestCase.java
@@ -17,7 +17,9 @@
 package org.jboss.aerogear.android.pipe.test.util;
 
 import android.app.Activity;
-import android.test.ActivityInstrumentationTestCase2;
+import android.content.Intent;
+import android.support.test.rule.ActivityTestRule;
+import org.junit.Before;
 
 /**
  * All tests which use Mockito should extend this class.
@@ -27,19 +29,25 @@ import android.test.ActivityInstrumentationTestCase2;
  * test setup.
  * 
  */
-public abstract class PatchedActivityInstrumentationTestCase<T extends Activity> extends ActivityInstrumentationTestCase2<T> {
+public abstract class PatchedActivityInstrumentationTestCase {
+    
+    private final ActivityTestRule rule;
 
-    public PatchedActivityInstrumentationTestCase(Class<T> activity) {
-        super(activity);
+    public PatchedActivityInstrumentationTestCase(Class<? extends Activity> klass) {
+        rule = new ActivityTestRule(klass, false, false);
     }
-
-    @Override
+    
+    @Before
     /**
      * Sets the dexcache property before test execution.
      */
-    protected void setUp() throws Exception {
-        super.setUp();
-        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
+    public void setDexcacheDir() throws Exception {
+        rule.launchActivity(new Intent(Intent.ACTION_MAIN));
+        System.setProperty("dexmaker.dexcache", rule.getActivity().getCacheDir().getPath());
+    }
+    
+    protected Activity getActivity() {
+        return rule.getActivity();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         
         <!-- Plugins versions -->
         <maven.javadoc.plugin.version>2.9.1</maven.javadoc.plugin.version>
-        <maven.android.plugin.version>4.2.0</maven.android.plugin.version>
+        <maven.android.plugin.version>4.2.1</maven.android.plugin.version>
         <builder.helper.plugin.version>1.7</builder.helper.plugin.version>
 
         <!-- Android configs -->


### PR DESCRIPTION
This PR updates the android-maven-plugin to version 4.2.1 and migrates the tests to JUnit 4 (which is newly available in 4.2.1)

To test:
 # Install the latest Android SDK stuff 
 # Run the android-maven-sdk-deployer 
 # Install aerogear-android-core 2.2.0-SNAPSHOT
 # run `mvn clean install` in the project root. (You need a running emulator or connected phone)
Results:
 You should see passing tests.

