### PR TITLE
update doc params to be in order from the method

### DIFF
--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/Pipe.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/Pipe.java
@@ -54,9 +54,9 @@ public interface Pipe<T> {
 
     /**
      * Reads all the data from the underlying server connection.
-     * 
-     * @param callback The callback for consuming the result from the {@link Pipe} invocation.
+     *
      * @param filter a {@link ReadFilter} for performing pagination and querying.
+     * @param callback The callback for consuming the result from the {@link Pipe} invocation.
      */
     void read(ReadFilter filter, Callback<List<T>> callback);
 


### PR DESCRIPTION
noticed that the params in the doc were not in the same order as in the method.  