### PR TITLE
Using redhat.com instead of the openshift controller image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   - mvn package -DskipTests=true;
 
   - emulator -avd test -no-skin -no-audio -no-window &
-  - wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/ci_environment/android-sdk/files/default/android-wait-for-emulator
+  - wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
   - chmod a+x ./android-wait-for-emulator
   - ./android-wait-for-emulator
   - adb shell input keyevent 82

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
@@ -540,7 +540,7 @@ public class RestAdapterTest {
     public void testRunTimeout() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
-        URL aerogearserverUrl = new URL("https://controller-aerogear.rhcloud.com/aerogear-controller-demo/");
+        URL aerogearserverUrl = new URL("https://redhat.com/");
         RestfulPipeConfiguration pipeConfig = PipeManager.config("listClassId", RestfulPipeConfiguration.class).withUrl(aerogearserverUrl);
         pipeConfig.timeout(1);
         RestAdapter<Data> adapter = (RestAdapter<Data>) pipeConfig.forClass(Data.class);


### PR DESCRIPTION
Motivation:

The timeout test tests that the pipe will timeout when it tries to connect to a service.  Previously we used the openshift instance for the AGCtonroller.  However, we have removed the controller and need to use a new url.