### PR TITLE
Bugfix to increase compatibility with android studio

### DIFF
--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/rest/multipart/MultipartRequestBuilder.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/rest/multipart/MultipartRequestBuilder.java
@@ -153,8 +153,12 @@ public class MultipartRequestBuilder<T> implements RequestBuilder<T> {
         ArrayList<Property> properties = new ArrayList<Property>();
 
         for (Field field : baseClass.getDeclaredFields()) {
-            Property property = new Property(baseClass, field.getName());
-            properties.add(property);
+            
+            if (!field.isSynthetic()) {
+                Property property = new Property(baseClass, field.getName());
+                properties.add(property);
+            }
+
         }
 
         return properties;


### PR DESCRIPTION
Android studio will create synthetic fields.  This means that applications which use instant run won't serialize objects correctly.  This fixes that bug.