### PR TITLE
Add supprt to Android Support library Fragment

### DIFF
--- a/aerogear-android-pipe-test/pom.xml
+++ b/aerogear-android-pipe-test/pom.xml
@@ -115,6 +115,13 @@
             <version>${android.support.test.version}</version>
             <type>aar</type>
         </dependency>
+        
+        <dependency>
+            <groupId>com.android.support</groupId>
+            <artifactId>support-v4</artifactId>
+            <version>23.4.0</version>
+            <type>aar</type>
+        </dependency>
 
     </dependencies>
 

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/MainActivity.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/MainActivity.java
@@ -16,13 +16,13 @@
  */
 package org.jboss.aerogear.android.pipe.test;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.WindowManager;
 import org.jboss.aerogear.android.pipe.test.*;
 
-public class MainActivity extends Activity {
+public class MainActivity extends FragmentActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/CallbackTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/loader/CallbackTest.java
@@ -17,8 +17,13 @@
 package org.jboss.aerogear.android.pipe.test.loader;
 
 import android.app.Activity;
+//import android.support.v4.app.FragmentActivity;
 import android.app.Fragment;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentManager.OnBackStackChangedListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
@@ -38,7 +43,7 @@ import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 
 @RunWith(AndroidJUnit4.class)
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class CallbackTest extends PatchedActivityInstrumentationTestCase {
 
     public CallbackTest() {
@@ -80,40 +85,72 @@ public class CallbackTest extends PatchedActivityInstrumentationTestCase {
         assertNull(UnitTestUtils.getSuperPrivateField(fragmentCallback, "fragment"));
 
     }
-    
-        @Test
-    public void testPassModernSupportFragmentCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
-        android.support.v4.app.Fragment fragment = Mockito.mock(android.support.v4.app.Fragment.class);
 
-        LoaderAdapter adapter = new LoaderAdapter(fragment, getActivity(), mock(Pipe.class), "ignore");
-        VoidSupportFragmentCallback fragmentCallback = new VoidSupportFragmentCallback();
-        ReadLoader loader = Mockito.mock(ReadLoader.class);
-        Mockito.when(loader.getCallback()).thenReturn(fragmentCallback);
+    @Test
+    public void testPassModernSupportFragmentCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException, InterruptedException {
+        final android.support.v4.app.Fragment fragment = new android.support.v4.app.Fragment();
+        final FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
 
-        Object data = "Data";
-        CallbackHandler handler = new CallbackHandler(adapter, loader, data);
-        handler.run();
-        assertTrue(fragmentCallback.successCalled);
-        assertNull(UnitTestUtils.getSuperPrivateField(fragmentCallback, "fragment"));
+        fragmentManager.beginTransaction().add(0, fragment).addToBackStack(null).commit();
+        fragmentManager.addOnBackStackChangedListener(new OnBackStackChangedListener() {
+            @Override
+            public void onBackStackChanged() {
+                LoaderAdapter adapter = new LoaderAdapter(fragment, getActivity(), mock(Pipe.class), "ignore");
+                VoidSupportFragmentCallback fragmentCallback = new VoidSupportFragmentCallback();
+                ReadLoader loader = Mockito.mock(ReadLoader.class);
+                Mockito.when(loader.getCallback()).thenReturn(fragmentCallback);
+
+                Object data = "Data";
+                CallbackHandler handler = new CallbackHandler(adapter, loader, data);
+                handler.run();
+                assertTrue(fragmentCallback.successCalled);
+                try {
+                    assertNull(UnitTestUtils.getSuperPrivateField(fragmentCallback, "fragment"));
+                } catch (NoSuchFieldException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (IllegalArgumentException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (IllegalAccessException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                }
+
+            }
+        });
 
     }
 
     @Test
     public void testFailModernSupportFragmentCallbacks() throws IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
-        android.support.v4.app.Fragment fragment = Mockito.mock(android.support.v4.app.Fragment.class);
+        final android.support.v4.app.Fragment fragment = new android.support.v4.app.Fragment();
+        final FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
 
-        LoaderAdapter adapter = new LoaderAdapter(fragment, getActivity(), mock(Pipe.class), "ignore");
-        VoidSupportFragmentCallback fragmentCallback = new VoidSupportFragmentCallback();
-        ReadLoader loader = Mockito.mock(ReadLoader.class);
-        Mockito.when(loader.getCallback()).thenReturn(fragmentCallback);
-        Mockito.when(loader.hasException()).thenReturn(true);
-        Mockito.when(loader.getException()).thenReturn(new RuntimeException("This is only a test exception."));
+        fragmentManager.beginTransaction().add(0, fragment).addToBackStack(null).commit();
+        fragmentManager.addOnBackStackChangedListener(new OnBackStackChangedListener() {
+            @Override
+            public void onBackStackChanged() {
+                LoaderAdapter adapter = new LoaderAdapter(fragment, getActivity(), mock(Pipe.class), "ignore");
+                VoidSupportFragmentCallback fragmentCallback = new VoidSupportFragmentCallback();
+                ReadLoader loader = Mockito.mock(ReadLoader.class);
+                Mockito.when(loader.getCallback()).thenReturn(fragmentCallback);
+                Mockito.when(loader.hasException()).thenReturn(true);
+                Mockito.when(loader.getException()).thenReturn(new RuntimeException("This is only a test exception."));
 
-        Object data = "Data";
-        CallbackHandler handler = new CallbackHandler(adapter, loader, data);
-        handler.run();
-        assertTrue(fragmentCallback.failCalled);
-        assertNull(UnitTestUtils.getSuperPrivateField(fragmentCallback, "fragment"));
+                Object data = "Data";
+                CallbackHandler handler = new CallbackHandler(adapter, loader, data);
+                handler.run();
+                assertTrue(fragmentCallback.failCalled);
+                try {
+                    assertNull(UnitTestUtils.getSuperPrivateField(fragmentCallback, "fragment"));
+                } catch (NoSuchFieldException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (IllegalArgumentException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (IllegalAccessException ex) {
+                    Logger.getLogger(CallbackTest.class.getName()).log(Level.SEVERE, null, ex);
+                }
+
+            }
+        });
 
     }
 
@@ -175,8 +212,8 @@ public class CallbackTest extends PatchedActivityInstrumentationTestCase {
         }
 
     }
-    
-        private static class VoidSupportFragmentCallback extends AbstractSupportFragmentCallback<Object> {
+
+    private static class VoidSupportFragmentCallback extends AbstractSupportFragmentCallback<Object> {
 
         boolean successCalled = false;
         boolean failCalled = false;

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
@@ -323,6 +323,7 @@ public class RestAdapterTest {
         assertEquals(listClass.points, returnedPoints);
     }
 
+    @Test
     public void runReadWithFilterUsingUri() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -350,7 +351,7 @@ public class RestAdapterTest {
         });
         latch.await(500, TimeUnit.MILLISECONDS);
 
-        verify(factory).get(eq(new URL(url.toString() + "rail%2Ftrails?limit=10&where=%7B%22model%22:%22BMW%22%7D")));
+        verify(factory).get(Mockito.argThat(new ObjectVarArgsMatcher(new URL(url.toString() + "rail%2Ftrails?limit=10&where=%7B%22model%22:%22BMW%22%7D"), 60000)));
     }
     
     public void testEscapeComplexUri() throws Exception {

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/rest/RestAdapterTest.java
@@ -354,6 +354,7 @@ public class RestAdapterTest {
         verify(factory).get(Mockito.argThat(new ObjectVarArgsMatcher(new URL(url.toString() + "rail%2Ftrails?limit=10&where=%7B%22model%22:%22BMW%22%7D"), 60000)));
     }
     
+    @Test
     public void testEscapeComplexUri() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -382,8 +383,8 @@ public class RestAdapterTest {
         });
         latch.await(500, TimeUnit.MILLISECONDS);
 
-        verify(factory).get(eq(new URL(url.toString() + "metrics/gauges/MI~R~%5Bacbfe3d2-fd73-43b0-94ad-c38f32abba1f"
-                + "%2FHolu~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data?start=1463907826698&end=1466586226698")));
+        verify(factory).get(Mockito.argThat(new ObjectVarArgsMatcher(new URL(url.toString() + "metrics/gauges/MI~R~%5Bacbfe3d2-fd73-43b0-"
+                + "94ad-c38f32abba1f%2FHolu~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data?start=1463907826698&end=1466586226698"), 60000)));
     }
 
     public void runReadWithFilter() throws Exception {

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/PatchedActivityInstrumentationTestCase.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/PatchedActivityInstrumentationTestCase.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.aerogear.android.pipe.test.util;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 import org.junit.Before;
@@ -33,7 +33,7 @@ public abstract class PatchedActivityInstrumentationTestCase {
     
     private final ActivityTestRule rule;
 
-    public PatchedActivityInstrumentationTestCase(Class<? extends Activity> klass) {
+    public PatchedActivityInstrumentationTestCase(Class<? extends FragmentActivity> klass) {
         rule = new ActivityTestRule(klass, false, false);
     }
     
@@ -46,8 +46,8 @@ public abstract class PatchedActivityInstrumentationTestCase {
         System.setProperty("dexmaker.dexcache", rule.getActivity().getCacheDir().getPath());
     }
     
-    protected Activity getActivity() {
-        return rule.getActivity();
+    protected FragmentActivity getActivity() {
+        return (FragmentActivity)(rule.getActivity());
     }
 
 }

--- a/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/StubActivity.java
+++ b/aerogear-android-pipe-test/src/main/java/org/jboss/aerogear/android/pipe/test/util/StubActivity.java
@@ -16,10 +16,10 @@
  */
 package org.jboss.aerogear.android.pipe.test.util;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 import android.os.Bundle;
 
-public class StubActivity extends Activity {
+public class StubActivity extends FragmentActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/aerogear-android-pipe/pom.xml
+++ b/aerogear-android-pipe/pom.xml
@@ -69,6 +69,13 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>com.android.support</groupId>
+            <artifactId>support-v4</artifactId>
+            <version>23.4.0</version>
+            <type>aar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/PipeManager.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/PipeManager.java
@@ -138,5 +138,22 @@ public class PipeManager {
         adapter.setLoaderIds(loaderIdsForNamed);
         return adapter;
     }
+    
+    /**
+     * Look up for a pipe object. This will wrap the Pipe in a Loader.
+     * 
+     * @param name the name of the actual pipe
+     * @param fragment the Fragment whose lifecycle the activity will follow
+     * @param applicationContext the Context of the application.
+     * 
+     * @return the new created Pipe object
+     * 
+     */
+    public static LoaderPipe getPipe(String name, android.support.v4.app.Fragment fragment, Context applicationContext) {
+        Pipe pipe = pipes.get(name);
+        LoaderAdapter adapter = new LoaderAdapter(fragment, applicationContext, pipe, name);
+        adapter.setLoaderIds(loaderIdsForNamed);
+        return adapter;
+    }
 
 }

--- a/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/callback/AbstractSupportFragmentCallback.java
+++ b/aerogear-android-pipe/src/main/java/org/jboss/aerogear/android/pipe/callback/AbstractSupportFragmentCallback.java
@@ -1,0 +1,75 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.android.pipe.callback;
+
+import org.jboss.aerogear.android.pipe.loader.AbstractPipeLoader;
+
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.Fragment;
+import java.util.Arrays;
+
+/**
+ * 
+ * {@link org.jboss.aerogear.android.pipe.LoaderPipe} which consume
+ * callbacks of this type will supply it with a {@link FragmentActivity} instance before
+ * onSuccess or onFailure are called. This should not be done by the user.
+ * 
+ * These calls are not guaranteed to be thread safe. Instances of the callback
+ * should not be shared among Activities and Fragments.
+ * 
+ * After onSuccess or onFailure have been called, the fragment will be set to
+ * null.
+ * 
+ * @param <T> the type of data to be passed on onSuccess
+ */
+public abstract class AbstractSupportFragmentCallback<T> extends AbstractCallback<T> {
+
+    private transient Fragment fragment;
+
+    /**
+     * This accepts an arbitrary list of Object and uses {@link Arrays#hashCode(java.lang.Object[])  } to
+     * generate a hashcode. This code is used to provided the loader manager
+     * with a unique value to determine uniqueness of calls to read, etc.
+     * 
+     * @param params A collection of objects which will be used to generate a
+     *            hashcode
+     */
+    public AbstractSupportFragmentCallback(Object... params) {
+        super(params);
+    }
+
+    /**
+     * This method should be called in the onSuccess or onFailure methods of
+     * subclasses.
+     * 
+     * @return the fragment instance
+     */
+    protected Fragment getSupportFragment() {
+        return fragment;
+    }
+
+    /**
+     * This method is called by {@link AbstractPipeLoader} or
+     * AbstractAuthenticationLoader during the onLoadComplete
+     * method before onSuccess or onFailure are called.
+     * 
+     * @param fragment the fragment which will handle this callback
+     */
+    public void setSupportFragment(Fragment fragment) {
+        this.fragment = fragment;
+    }
+}


### PR DESCRIPTION
Take advantage the Activity behind support fragment
- Add AbstractSupportFragmentCallback
- Shift MainActivity to FragmetActivity in test package.
- Add 2 Test cases for callback related to Support Fragment